### PR TITLE
Fixing location of breadcrumb on clusters page.

### DIFF
--- a/app/views/clusters.html
+++ b/app/views/clusters.html
@@ -1,8 +1,8 @@
 <project-header class="top-header"></project-header>
 <project-page class="project-overview-page">
 <div class="container-cards-pf dashboard-cards">
-    <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <div class="card-pf card-pf-double" id="cluster-list">
+        <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
         <div class="card-pf-heading">
             <div class="pull-right">
                 <button class="btn btn-primary" id="startbutton" ng-click="newCluster()"


### PR DESCRIPTION
It's no longer smashed up against the left panel.
