### PR TITLE
Cluster actions are now in a dropdown

### DIFF
--- a/app/views/oshinko/clusters.html
+++ b/app/views/oshinko/clusters.html
@@ -26,8 +26,7 @@
                         <th>Status</th>
                         <th>Master</th>
                         <th>Worker count</th>
-                        <th></th>
-                        <th></th>
+                        <th><span class="sr-only">Actions</span></th>
                     </tr>
                 </thead>
                 <tbody  ng-repeat="cluster in oshinkoClusterNames" ng-init="id = cluster" name="cluster-row-{{ $index }}" data-id="{{ id }}">
@@ -41,13 +40,21 @@
                     </td>
                     <td name="masterurl-{{ cluster }}" ng-click="gotoCluster(cluster)">{{ getSparkMasterUrl(oshinkoClusters[cluster]) }}</td>
                     <td name="workercount-{{ cluster }}" ng-click="gotoCluster(cluster)">{{ countWorkers(oshinkoClusters[cluster]) }}</td>
-                    <td>
-                        <button name="scalebutton-{{cluster}}" class="btn btn-default" translatable="yes" ng-click="scaleCluster(cluster, countWorkers(oshinkoClusters[cluster]))">Scale</button>
-                    </td>
-                    <td>
-                        <a name="deletebutton-{{ cluster }}" class="delete-icon">
-                            <i translatable="yes" class=" pficon-delete" ng-click="deleteCluster(cluster)"></i>
-                        </a>
+                    <td data-title="Actions" class="text-xs-left text-right">
+                        <span uib-dropdown>
+                            <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                              Actions
+                              <span class="caret" aria-hidden="true"></span>
+                            </button>
+                            <ul class="uib-dropdown-menu dropdown-menu-right">
+                                <li>
+                                    <a href="" role="button" ng-click="scaleCluster(cluster, countWorkers(oshinkoClusters[cluster]))">Scale Cluster</a>
+                                </li>
+                                <li>
+                                    <a href="" role="button" ng-click="deleteCluster(cluster)">Delete Cluster</a>
+                                </li>
+                            </ul>
+                        </span>
                     </td>
                 </tr>
                 </tbody>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -32,8 +32,8 @@ function g(a, b) {
 var c = null;
 d.list("replicationcontrollers", s, function(e) {
 var f = e.by("metadata.name");
-angular.forEach(f, function(d) {
-d.metadata.labels["oshinko-cluster"] === a && d.metadata.name.startsWith(b) && (!c || new Date(d.metadata.creationTimestamp) > new Date(c.metadata.creationTimestamp)) && (c = d);
+angular.forEach(f, function(e) {
+e.metadata.labels["oshinko-cluster"] === a && e.metadata.name.startsWith(b) && (!c || new Date(e.metadata.creationTimestamp) > new Date(c.metadata.creationTimestamp)) && (c && d["delete"]("replicationcontrollers", c.metadata.name, s, null).then(angular.noop), c = e);
 }), c.spec.replicas = 0, d.update("replicationcontrollers", c.metadata.name, c, s).then(function() {
 return d["delete"]("replicationcontrollers", c.metadata.name, s, null);
 });

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -97,8 +97,7 @@ angular.module('oshinkoConsoleTemplates', []).run(['$templateCache', function($t
     "<th>Status</th>\n" +
     "<th>Master</th>\n" +
     "<th>Worker count</th>\n" +
-    "<th></th>\n" +
-    "<th></th>\n" +
+    "<th><span class=\"sr-only\">Actions</span></th>\n" +
     "</tr>\n" +
     "</thead>\n" +
     "<tbody ng-repeat=\"cluster in oshinkoClusterNames\" ng-init=\"id = cluster\" name=\"cluster-row-{{ $index }}\" data-id=\"{{ id }}\">\n" +
@@ -112,13 +111,21 @@ angular.module('oshinkoConsoleTemplates', []).run(['$templateCache', function($t
     "</td>\n" +
     "<td name=\"masterurl-{{ cluster }}\" ng-click=\"gotoCluster(cluster)\">{{ getSparkMasterUrl(oshinkoClusters[cluster]) }}</td>\n" +
     "<td name=\"workercount-{{ cluster }}\" ng-click=\"gotoCluster(cluster)\">{{ countWorkers(oshinkoClusters[cluster]) }}</td>\n" +
-    "<td>\n" +
-    "<button name=\"scalebutton-{{cluster}}\" class=\"btn btn-default\" translatable=\"yes\" ng-click=\"scaleCluster(cluster, countWorkers(oshinkoClusters[cluster]))\">Scale</button>\n" +
-    "</td>\n" +
-    "<td>\n" +
-    "<a name=\"deletebutton-{{ cluster }}\" class=\"delete-icon\">\n" +
-    "<i translatable=\"yes\" class=\"pficon-delete\" ng-click=\"deleteCluster(cluster)\"></i>\n" +
-    "</a>\n" +
+    "<td data-title=\"Actions\" class=\"text-xs-left text-right\">\n" +
+    "<span uib-dropdown>\n" +
+    "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
+    "Actions\n" +
+    "<span class=\"caret\" aria-hidden=\"true\"></span>\n" +
+    "</button>\n" +
+    "<ul class=\"uib-dropdown-menu dropdown-menu-right\">\n" +
+    "<li>\n" +
+    "<a href=\"\" role=\"button\" ng-click=\"scaleCluster(cluster, countWorkers(oshinkoClusters[cluster]))\">Scale Cluster</a>\n" +
+    "</li>\n" +
+    "<li>\n" +
+    "<a href=\"\" role=\"button\" ng-click=\"deleteCluster(cluster)\">Delete Cluster</a>\n" +
+    "</li>\n" +
+    "</ul>\n" +
+    "</span>\n" +
     "</td>\n" +
     "</tr>\n" +
     "</tbody>\n" +


### PR DESCRIPTION
To look closer to the origin console, cluster actions
now appear in an "Actions" dropdown in the clusters
table.  This was recommended at the UI review.