### PR TITLE
Removing need to have a rest pod to show our oshinko link.

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -11,48 +11,8 @@
           });
         }
       ])
-    .run(function ($routeParams, extensionRegistry) {
-        var template = [
-            '<div row ',
-            'ng-show="item.url" ',
-            'class="icon-row" ',
-            'title="Connect to container">',
-            '<div>',
-            '<i class="fa fa-share" aria-hidden="true"></i>',
-            '</div>',
-            '<div flex>',
-            '<a ng-href="{{item.url}}">',
-            'Manage Spark Clusters',
-            '</a>',
-            '</div>',
-            '</div>'
-        ].join('');
-
-        var makeOshinkoUrl = function () {
-            var namespace = $routeParams.project;
-            return new URI("project/" + namespace + "/oshinko");
-        };
-
-        extensionRegistry.add('container-links', _.spread(function (container, pod) {
-            var oshinkoUrl = makeOshinkoUrl().toString();
-            var oshinkoPort = _.find((container.ports || []), function (port) {
-                return port.name && port.name.toLowerCase() === 'o-rest-port';
-            });
-
-            if (!oshinkoPort) {
-                return;
-            }
-            if (pod.metadata.annotations["openshift.io/deployment-config.name"] !== "oshinko") {
-                return;
-            }
-
-            return {
-                type: 'dom',
-                node: template,
-                url: oshinkoUrl
-            };
-
-        }));
+    .run(function () {
+        window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION.push({href: "/oshinko", label: "Spark Clusters", iconClass:"pficon  pficon-cluster"});
     });
     hawtioPluginLoader.addModule(extName);
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7,22 +7,13 @@ a.when("/project/:project/oshinko", {
 templateUrl:"views/oshinko/clusters.html",
 controller:"OshinkoClustersCtrl"
 });
-} ]).run([ "$routeParams", "extensionRegistry", function(a, b) {
-var c = [ "<div row ", 'ng-show="item.url" ', 'class="icon-row" ', 'title="Connect to container">', "<div>", '<i class="fa fa-share" aria-hidden="true"></i>', "</div>", "<div flex>", '<a ng-href="{{item.url}}">', "Manage Spark Clusters", "</a>", "</div>", "</div>" ].join(""), d = function() {
-var b = a.project;
-return new URI("project/" + b + "/oshinko");
-};
-b.add("container-links", _.spread(function(a, b) {
-var e = d().toString(), f = _.find(a.ports || [], function(a) {
-return a.name && "o-rest-port" === a.name.toLowerCase();
+} ]).run(function() {
+window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION.push({
+href:"/oshinko",
+label:"Spark Clusters",
+iconClass:"pficon  pficon-cluster"
 });
-if (f && "oshinko" === b.metadata.annotations["openshift.io/deployment-config.name"]) return {
-type:"dom",
-node:c,
-url:e
-};
-}));
-} ]), hawtioPluginLoader.addModule(a);
+}), hawtioPluginLoader.addModule(a);
 }(), angular.module("oshinkoConsole").factory("clusterData", [ "$http", "$q", "ProjectsService", "DataService", "DeploymentsService", "$routeParams", function(a, b, c, d, e, f) {
 function g(a, b) {
 return d["delete"](b, a, u, null);


### PR DESCRIPTION
Instead, oshinko is now available via the left hand nav.