### PR TITLE
remove angular-key-value-editor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,6 @@
     "ng-sortable": "1.3.4",
     "ui-select": "angular-ui-select#0.19.4",
     "matchHeight": "0.6.0",
-    "angular-key-value-editor": "2.9.0",
     "angular-inview": "1.5.7",
     "js-yaml": "3.6.1"
   },


### PR DESCRIPTION
removing angular-key-value-editor as it is being removed from origin console.