### PR TITLE
[CI/CD] Creating release subproject for jenkins to preform releases

### DIFF
--- a/distro-assembly/pom.xml
+++ b/distro-assembly/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.radanalytics.openshift</groupId>
+	<artifactId>oshinko-console-extension</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<name>RADANALYTICSIO :: OSHINKO-CONSOLE :: OpenShift Extension Assembly</name>
+	<description>Radanalyticsio oshinko console extension</description>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptor>src/assembly/assembly.xml</descriptor>
+				</configuration>
+				<executions>
+					<execution>
+						<id>create-archive</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/distro-assembly/src/assembly/assembly.xml
+++ b/distro-assembly/src/assembly/assembly.xml
@@ -1,0 +1,20 @@
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<id>bin</id>
+	<formats>
+		<format>tar.gz</format>
+		<format>tar.bz2</format>
+		<format>zip</format>
+	</formats>
+	<fileSets>
+		<fileSet>
+			<directory>../dist</directory>
+			<outputDirectory>/</outputDirectory>
+			<excludes>
+				<exclude>index.html</exclude>
+			</excludes>
+		</fileSet>
+	</fileSets>
+</assembly>


### PR DESCRIPTION
OpenShift console extension only requires *.js, *.css files to run the extension on openshift. I want to trigger this build to cut a release so I can fetch it from github release page for this project instead of performing manual builds.

prerequisite is to have jenkins perform the following before cutting the release zip file
```bash
gem install bundler
sudo npm install
bower install
grunt build 

```